### PR TITLE
Fetch athlete gear

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,0 +1,7 @@
+import_if_available(Ecto.Query)
+
+alias StravaGearData.Api
+alias StravaGearData.Athletes
+alias StravaGearData.Authorization
+alias StravaGearData.DataCollection
+alias StravaGearData.Repo

--- a/lib/strava_gear_data/api/athlete.ex
+++ b/lib/strava_gear_data/api/athlete.ex
@@ -7,7 +7,9 @@ defmodule StravaGearData.Api.Athlete do
     :firstname,
     :lastname,
     :username,
-    :profile_medium
+    :profile_medium,
+    bikes: [],
+    shoes: []
   ]
 
   @type t :: %__MODULE__{
@@ -15,7 +17,16 @@ defmodule StravaGearData.Api.Athlete do
           firstname: String.t(),
           lastname: String.t(),
           username: String.t(),
-          profile_medium: String.t()
+          profile_medium: String.t(),
+          bikes: [gear_t()] | nil,
+          shoes: [gear_t()] | nil
+        }
+
+  @type gear_t :: %{
+          id: String.t(),
+          primary: boolean(),
+          name: String.t(),
+          distance: float()
         }
 
   def from!(%OAuth2.AccessToken{
@@ -37,4 +48,41 @@ defmodule StravaGearData.Api.Athlete do
       profile_medium: profile_medium
     })
   end
+
+  def from!(%{
+        "id" => id,
+        "firstname" => firstname,
+        "lastname" => lastname,
+        "username" => username,
+        "profile_medium" => profile_medium,
+        "bikes" => bikes,
+        "shoes" => shoes
+      }) do
+    struct!(__MODULE__, %{
+      id: id,
+      firstname: firstname,
+      lastname: lastname,
+      username: username,
+      profile_medium: profile_medium,
+      bikes: gear_from!(bikes),
+      shoes: gear_from!(shoes)
+    })
+  end
+
+  def from!(_), do: nil
+
+  def gear_from!(gear) when is_list(gear), do: Enum.map(gear, &gear_from!/1)
+
+  def gear_from!(%{
+        "id" => id,
+        "primary" => primary,
+        "name" => name,
+        "distance" => distance
+      }),
+      do: %{
+        id: id,
+        primary: primary,
+        name: name,
+        distance: distance
+      }
 end

--- a/lib/strava_gear_data/api/auth.ex
+++ b/lib/strava_gear_data/api/auth.ex
@@ -25,6 +25,10 @@ defmodule StravaGearData.Api.Auth do
     |> Client.put_serializer("application/json", Jason)
   end
 
+  def access_token(params), do: OAuth2.AccessToken.new(params)
+
+  def expired?(token), do: OAuth2.AccessToken.expired?(token)
+
   def authorize_url! do
     Client.authorize_url!(client(),
       scope: "read,activity:read,profile:read_all",

--- a/lib/strava_gear_data/athletes.ex
+++ b/lib/strava_gear_data/athletes.ex
@@ -28,6 +28,12 @@ defmodule StravaGearData.Athletes do
   def get_athlete_by_strava_id(strava_id), do: Repo.get_by(Athlete, strava_id: strava_id)
 
   @doc """
+  Preload athlete tokens
+  """
+  @spec preload_tokens(Athlete.t()) :: Athlete.t()
+  def preload_tokens(athlete), do: Repo.preload(athlete, [:access_token, :refresh_token])
+
+  @doc """
   Creates a athlete.
 
   ## Examples

--- a/lib/strava_gear_data/athletes/athlete.ex
+++ b/lib/strava_gear_data/athletes/athlete.ex
@@ -7,6 +7,7 @@ defmodule StravaGearData.Athletes.Athlete do
 
   alias StravaGearData.Athletes.AccessToken
   alias StravaGearData.Athletes.RefreshToken
+  alias StravaGearData.Gear.Gear
 
   @type t :: %__MODULE__{
           id: binary(),
@@ -14,7 +15,10 @@ defmodule StravaGearData.Athletes.Athlete do
           first_name: String.t() | nil,
           last_name: String.t() | nil,
           username: String.t() | nil,
-          profile_picture: String.t() | nil
+          profile_picture: String.t() | nil,
+          gear: [Gear] | nil,
+          access_token: AccessToken | nil,
+          refresh_token: RefreshToken | nil
         }
 
   @primary_key {:id, :binary_id, autogenerate: true}
@@ -24,6 +28,8 @@ defmodule StravaGearData.Athletes.Athlete do
     field :last_name, :string
     field :username, :string
     field :profile_picture, :string
+
+    has_many :gear, Gear, on_replace: :delete_if_exists
 
     has_one :access_token, AccessToken, on_replace: :update
     has_one :refresh_token, RefreshToken, on_replace: :update

--- a/lib/strava_gear_data/authorization.ex
+++ b/lib/strava_gear_data/authorization.ex
@@ -14,11 +14,24 @@ defmodule StravaGearData.Authorization do
   @spec authorize_athlete_from!(code: binary()) ::
           {:ok, Athletes.Athlete.t()} | {:error, Ecto.Changeset.t()}
   def authorize_athlete_from!(params) do
-    api_token = Api.exchange_code_for_token(params)
+    params
+    |> Api.exchange_code_for_token()
+    |> update_athlete_tokens()
+  end
 
+  def update_athlete_tokens(api_token) do
     api_token
-    |> build_athlete_attrs()
+    |> build_athlete_attrs
     |> insert_or_update_athlete()
+  end
+
+  def update_athlete_tokens(%Athlete{} = athlete, api_token) do
+    attrs =
+      %{}
+      |> put_access_token_attrs(api_token)
+      |> put_refresh_token_attrs(api_token)
+
+    Athletes.update_athlete(athlete, attrs)
   end
 
   @doc false

--- a/lib/strava_gear_data/data_collection.ex
+++ b/lib/strava_gear_data/data_collection.ex
@@ -1,0 +1,58 @@
+defmodule StravaGearData.DataCollection do
+  @moduledoc """
+  Context to handle gathering data from Strava and persisting it to our
+  database
+  """
+  alias StravaGearData.Api
+  alias StravaGearData.Gear
+  alias StravaGearData.Repo
+
+  @doc """
+  Gather the athlete's gear from Strava and persist it to the DB
+  """
+  def gather_athlete_gear(athlete) do
+    athlete = Repo.preload(athlete, :gear)
+    api_athlete = Api.get_athlete(athlete)
+
+    gear_attrs = build_gear_attrs(athlete, api_athlete)
+    {_, nil} = Gear.insert_all(gear_attrs)
+  end
+
+  @doc false
+  def build_gear_attrs(athlete, %{bikes: bikes, shoes: shoes}) do
+    []
+    |> do_build_gear_attrs(bikes)
+    |> do_build_gear_attrs(shoes)
+    |> Stream.map(
+      &Map.put_new(&1, :inserted_at, NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second))
+    )
+    |> Stream.map(
+      &Map.put_new(&1, :updated_at, NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second))
+    )
+    |> Stream.map(fn attrs ->
+      case Enum.find(athlete.gear, &(&1.strava_id == attrs["strava_id"])) do
+        nil -> attrs
+        matched_gear -> Map.put(attrs, :id, matched_gear.id)
+      end
+    end)
+    |> Enum.map(&Map.put(&1, :athlete_id, athlete.id))
+  end
+
+  @spec do_build_gear_attrs(list(), [Api.Athlete.gear_t()]) :: [map()]
+  defp do_build_gear_attrs(gear_attrs, [gear_data | tail]),
+    do: do_build_gear_attrs([cast_gear(gear_data) | gear_attrs], tail)
+
+  defp do_build_gear_attrs(gear_attrs, []), do: gear_attrs
+
+  @spec cast_gear(Api.Athlete.gear_t()) :: map()
+  def cast_gear(%{
+        id: strava_id,
+        name: name,
+        primary: primary
+      }),
+      do: %{
+        strava_id: strava_id,
+        name: name,
+        primary: primary
+      }
+end

--- a/lib/strava_gear_data/gear.ex
+++ b/lib/strava_gear_data/gear.ex
@@ -1,0 +1,27 @@
+defmodule StravaGearData.Gear do
+  @moduledoc """
+  The Gear context
+  """
+
+  alias StravaGearData.Gear.Gear
+  alias StravaGearData.Repo
+
+  @doc """
+  Insert all the gear given by the provided gear attrs.
+
+  This does a batch insert of all the provided gear and expects the attrs to
+  include the associated athlete ID and timestamps.
+
+  On conflict of the strava_id all fields are replaced except for the:
+    - id
+    - strava_id
+    - inserted_at
+  """
+  @spec insert_all([Gear.gear_attrs_t()]) :: {integer(), nil}
+  def insert_all(gear_attrs) do
+    Repo.insert_all(Gear, gear_attrs,
+      conflict_target: :strava_id,
+      on_conflict: {:replace_all_except, [:id, :strava_id, :inserted_at]}
+    )
+  end
+end

--- a/lib/strava_gear_data/gear/gear.ex
+++ b/lib/strava_gear_data/gear/gear.ex
@@ -7,13 +7,29 @@ defmodule StravaGearData.Gear.Gear do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias StravaGearData.Athletes.Athlete
+
+  @type t :: %__MODULE__{
+          name: binary(),
+          primary: boolean(),
+          strava_id: binary(),
+          athlete: Athlete.t()
+        }
+
+  @type gear_attrs_t :: %{
+          name: binary(),
+          primary: boolean(),
+          strava_id: binary(),
+          athlete_id: binary()
+        }
+
   @primary_key {:id, :binary_id, autogenerate: true}
   schema "gear" do
     field :name, :string
     field :primary, :boolean, default: false
     field :strava_id, :string
 
-    belongs_to :athlete, StravaGearData.Athletes.Athlete, type: :binary_id
+    belongs_to :athlete, Athlete, type: :binary_id
 
     timestamps()
   end

--- a/test/strava_gear_data/data_collection_test.exs
+++ b/test/strava_gear_data/data_collection_test.exs
@@ -1,0 +1,49 @@
+defmodule StravaGearData.DataCollectionTest do
+  use StravaGearData.DataCase, async: true
+
+  alias StravaGearData.DataCollection
+
+  describe "build_gear_attrs/2" do
+    test "returns empty array for no gear" do
+      athlete = insert(:athlete)
+      api_athlete = build(:api_athlete)
+
+      assert [] == DataCollection.build_gear_attrs(athlete, api_athlete)
+    end
+
+    test "returns array of gear attrs for bike" do
+      athlete = :athlete |> insert() |> Repo.preload(:gear)
+
+      api_athlete = build(:api_athlete) |> with_bikes()
+
+      assert [_bike_attrs] = DataCollection.build_gear_attrs(athlete, api_athlete)
+    end
+
+    test "returns array of gear attrs for shoes" do
+      athlete = :athlete |> insert() |> Repo.preload(:gear)
+
+      api_athlete = build(:api_athlete) |> with_shoes()
+
+      assert [_shoeattrs] = DataCollection.build_gear_attrs(athlete, api_athlete)
+    end
+
+    test "returns array of gear attrs for shoes and bikes" do
+      athlete = :athlete |> insert() |> Repo.preload(:gear)
+      api_athlete = :api_athlete |> build() |> with_bikes(2) |> with_shoes(2)
+
+      assert [_, _, _, _] = DataCollection.build_gear_attrs(athlete, api_athlete)
+    end
+  end
+
+  describe "cast_gear/1" do
+    test "casts gear correctly" do
+      api_gear = build(:api_gear)
+
+      assert %{
+               strava_id: api_gear.id,
+               name: api_gear.name,
+               primary: api_gear.primary
+             } == DataCollection.cast_gear(api_gear)
+    end
+  end
+end

--- a/test/strava_gear_data/gear_test.exs
+++ b/test/strava_gear_data/gear_test.exs
@@ -1,0 +1,57 @@
+defmodule StravaGearData.GearTest do
+  use StravaGearData.DataCase, async: true
+
+  alias StravaGearData.Gear
+
+  describe "insert_all/1" do
+    test "inserts new gear" do
+      athlete = insert(:athlete)
+
+      attrs = [
+        %{
+          athlete_id: athlete.id,
+          strava_id: "gear_id",
+          name: "gear_name",
+          primary: true,
+          inserted_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second),
+          updated_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+        }
+      ]
+
+      assert {1, _} = Gear.insert_all(attrs)
+
+      gear_attrs = List.first(attrs)
+      %{gear: [updated_gear]} = athlete |> Repo.reload() |> Repo.preload(:gear)
+
+      assert updated_gear.strava_id == gear_attrs.strava_id
+      assert updated_gear.name == gear_attrs.name
+      assert updated_gear.primary == gear_attrs.primary
+    end
+
+    test "updates existing gear" do
+      %{gear: [original_gear]} = athlete = :athlete |> build() |> with_gear() |> insert()
+
+      attrs = [
+        %{
+          athlete_id: athlete.id,
+          strava_id: original_gear.strava_id,
+          name: "new name",
+          primary: true,
+          inserted_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second),
+          updated_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+        }
+      ]
+
+      assert {1, _} = Gear.insert_all(attrs)
+
+      gear_attrs = List.first(attrs)
+      %{gear: [updated_gear]} = athlete |> Repo.reload() |> Repo.preload(:gear)
+
+      assert updated_gear.strava_id == original_gear.strava_id
+      assert updated_gear.name == gear_attrs.name
+      assert updated_gear.primary == gear_attrs.primary
+
+      assert updated_gear.inserted_at == original_gear.inserted_at
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -40,6 +40,19 @@ defmodule StravaGearData.Factory do
     |> with_refresh_token()
   end
 
+  def with_gear(athlete, count \\ 1) do
+    %{athlete | gear: build_list(count, :gear, athlete: nil)}
+  end
+
+  def gear_factory() do
+    %StravaGearData.Gear.Gear{
+      athlete: build(:athlete),
+      strava_id: sequence("strava_gear_id"),
+      name: sequence("gear_name"),
+      primary: false
+    }
+  end
+
   def access_token_factory() do
     %StravaGearData.Athletes.AccessToken{
       athlete: build(:athlete),
@@ -53,6 +66,33 @@ defmodule StravaGearData.Factory do
     %StravaGearData.Athletes.RefreshToken{
       athlete: build(:athlete),
       token: "fake-token"
+    }
+  end
+
+  def api_athlete_factory() do
+    %StravaGearData.Api.Athlete{
+      id: 1234,
+      firstname: "Api",
+      lastname: "Athlete",
+      username: "api_athlete",
+      profile_medium: "https://profile.picture/of/athlete"
+    }
+  end
+
+  def with_shoes(api_athlete, count \\ 1) do
+    %{api_athlete | shoes: build_list(count, :api_gear)}
+  end
+
+  def with_bikes(api_athlete, count \\ 1) do
+    %{api_athlete | bikes: build_list(count, :api_gear)}
+  end
+
+  def api_gear_factory() do
+    %{
+      id: sequence("gear_id"),
+      name: sequence("gear_name"),
+      primary: false,
+      distance: 0 + :rand.uniform() * (10_000 - 0)
     }
   end
 end


### PR DESCRIPTION
Add the ability to fetch an athletes gear from Strava.

Add `DataCollection` module and tests to handle collecting data from
strava.

Add `Gear` module and tests to handle inserting gear into DB.

Add `Api.get_athlete/1` to fetch athlete from API. Ensure expired tokens
are refreshed and persisted before request is sent for the athlete.

This commit allows the collection of a user's gear from Stava and
persists it into the database.

Following this we will be able to fetch an athletes activities and
relate them to individual pieces of gear, allowing metrics to be
computed about gear beyond just the total distance provided by Strava.